### PR TITLE
Add functionality to call orion multiple times in app lifecycle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@akhilome/common": "^0.0.1",
     "caller": "^1.1.0",
     "chalk": "^4.1.2",
-    "fast-glob": "^3.2.11"
+    "fast-glob": "^3.2.11",
+    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "express": "^4.0.0",
@@ -39,6 +40,7 @@
     "@types/caller": "^1.0.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.4.0",
+    "@types/lodash.clonedeep": "^4.5.7",
     "@types/node": "^17.0.8",
     "@types/supertest": "^2.0.12",
     "esbuild": "^0.14.11",

--- a/src/lib/gather-routes.ts
+++ b/src/lib/gather-routes.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash.clonedeep';
 import { Route, RouteFile } from './types';
 import { HttpMethod, InvalidRouteError } from './utils';
 
@@ -33,18 +34,20 @@ export function gatherRoutes(paths: string[]) {
 }
 
 function attachRouteMeta(routes: RouteFile['routes'], meta?: RouteFile['meta']) {
-  if (!meta) return routes;
+  const _routes = cloneDeep(routes);
+
+  if (!meta) return _routes;
   const middlewares = meta.middlewares;
 
   if (meta.base) {
     const basePath = meta.base;
-    routes.forEach((r) => {
+    _routes.forEach((r) => {
       r.path = removeDuplicateSlashes(`/${basePath}/${r.path}`);
     });
   }
 
   if (middlewares?.length) {
-    routes.forEach((r) => {
+    _routes.forEach((r) => {
       if (r.middlewares) {
         r.middlewares = [...middlewares, ...r.middlewares];
       } else {
@@ -53,7 +56,7 @@ function attachRouteMeta(routes: RouteFile['routes'], meta?: RouteFile['meta']) 
     });
   }
 
-  return routes;
+  return _routes;
 }
 
 function removeDuplicateSlashes(path: string) {

--- a/src/lib/orion.ts
+++ b/src/lib/orion.ts
@@ -1,5 +1,4 @@
 import caller from 'caller';
-import { Application } from 'express';
 import fg from 'fast-glob';
 import path from 'path';
 
@@ -9,7 +8,7 @@ import { routeLogger } from './route-logger';
 import { OrionOptions } from './types';
 import { defaultOptions, validatePeerDeps } from './utils';
 
-export function orion(app: Application, opts: OrionOptions = defaultOptions) {
+export function orion(opts: OrionOptions = defaultOptions) {
   opts = { ...defaultOptions, ...opts };
   const callSite = caller();
   const callerExt = path.extname(callSite).split('.')[1];
@@ -26,11 +25,9 @@ export function orion(app: Application, opts: OrionOptions = defaultOptions) {
 
   const routes = gatherRoutes(paths);
 
-  routeLogger(routes, opts.logging);
+  routeLogger(routes, { suffix, ext, ...opts.logging });
 
   const router = generateRouter(routes, opts);
 
-  app.use(router);
-
-  return app;
+  return router;
 }

--- a/src/lib/route-logger.ts
+++ b/src/lib/route-logger.ts
@@ -5,10 +5,15 @@ import { OrionOptions, Route } from './types';
 const pad = (str: string) => ` ${str} `;
 const { log } = console;
 
-export function routeLogger(routes: Route[], opts: OrionOptions['logging'] = {}) {
+type RouteLoggerOptions = {
+  suffix: string;
+  ext: string;
+} & OrionOptions['logging'];
+
+export function routeLogger(routes: Route[], opts: RouteLoggerOptions) {
   if (!opts.enable) return;
 
-  log(`${EOL}✨ orion mapped routes ${EOL}`);
+  log(`${EOL}✨ [*.${opts.suffix}.${opts.ext}] ::: mapped routes ${EOL}`);
   routes.forEach(logRoute);
 }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,9 +2,9 @@ import express, { Application } from 'express';
 import request from 'supertest';
 import { orion } from '../src';
 
-let bareApp: Application;
-beforeAll(() => {
-  bareApp = express();
+let app: Application;
+beforeEach(() => {
+  app = express();
 });
 
 const defaultOptions = { validation: { enable: false }, logging: { enable: false } };
@@ -12,7 +12,7 @@ const defaultOptions = { validation: { enable: false }, logging: { enable: false
 describe('config', () => {
   it('should throw when validation enabled but no joi dep.', () => {
     try {
-      orion(bareApp);
+      orion();
     } catch (e) {
       const error = e as Error;
       expect(error).toBeDefined();
@@ -22,7 +22,7 @@ describe('config', () => {
 
   it('should not throw when no validation enabled and no joi dep.', () => {
     try {
-      orion(bareApp, { ...defaultOptions });
+      app.use(orion({ ...defaultOptions }));
     } catch (e) {
       const error = e as Error;
       expect(error).toBeUndefined();
@@ -30,7 +30,7 @@ describe('config', () => {
   });
 
   it('should look for different suffix when supplied', async () => {
-    const app = orion(bareApp, { ...defaultOptions, suffix: 'juls' });
+    app.use(orion({ ...defaultOptions, suffix: 'juls' }));
     const res = await request(app).get('/juls-1');
     const body = res.body as Record<string, unknown>;
 
@@ -41,16 +41,16 @@ describe('config', () => {
   it('should log to console when logging enabled', () => {
     const { Console } = console;
     const spy = jest.spyOn(Console.prototype, 'log');
-    orion(bareApp, { ...defaultOptions, logging: { enable: true } });
+    app.use(orion({ ...defaultOptions, logging: { enable: true } }));
 
     expect(spy).toHaveBeenCalled();
-    expect(spy.mock.calls[0].join('')).toMatch(/.*orion\smapped\sroutes.*/);
+    expect(spy.mock.calls[0].join('')).toMatch(/.*:::\smapped\sroutes.*/);
   });
 });
 
 describe('mapped paths', () => {
   it('should map paths correctly', async () => {
-    const app = orion(bareApp, { ...defaultOptions });
+    app.use(orion({ ...defaultOptions }));
 
     const res = await request(app).get('/path-1');
     const body = res.body as Record<string, unknown>;
@@ -60,7 +60,7 @@ describe('mapped paths', () => {
   });
 
   it('should skip paths with incorrect schema', async () => {
-    const app = orion(bareApp, { ...defaultOptions });
+    app.use(orion({ ...defaultOptions }));
 
     const res = await request(app).get('/lol-route');
 
@@ -70,7 +70,7 @@ describe('mapped paths', () => {
 
 describe('middlewares', () => {
   it('should correctly use middleware', async () => {
-    const app = orion(bareApp, { ...defaultOptions });
+    app.use(orion({ ...defaultOptions }));
 
     const res = await request(app).get('/mw-path-1');
     const body = res.body as Record<string, unknown>;
@@ -83,7 +83,7 @@ describe('middlewares', () => {
 
 describe('routes meta', () => {
   it('should correctly attach base path', async () => {
-    const app = orion(bareApp, { ...defaultOptions });
+    app.use(orion({ ...defaultOptions }));
 
     const res = await request(app).get('/test/path-1');
     const body = res.body as Record<string, unknown>;
@@ -93,7 +93,7 @@ describe('routes meta', () => {
   });
 
   it('should correctly use meta middlewares', async () => {
-    const app = orion(bareApp, { ...defaultOptions });
+    app.use(orion({ ...defaultOptions }));
 
     const res = await request(app).get('/test/path-2');
     const body = res.body as Record<string, unknown>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -815,6 +815,18 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/lodash.clonedeep@^4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz#0e119f582ed6f9e6b373c04a644651763214f197"
+  integrity sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -2761,6 +2773,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
 lodash.memoize@4.x:
   version "4.1.2"


### PR DESCRIPTION
Orion would now just return an express Router.

With this, orion can be called multiple times to generate a router given a specific suffix.

For ex:

```js
const app = express();

const demoRouter = orion({ suffix: 'demo' }); // routes from all files with pattern *.demo.ts (or *.demo.js if runtime is js)
const fooRouter = orion({ suffix: 'foo.route' }); // routes from all files with pattern *.foo.route.ts (or *.foo.route.js if runtime is js)

app.use(demoRouter);
app.use(fooRouter);

app.listen( ... ) 
```