### PR TITLE
feat: add support for root base

### DIFF
--- a/src/lib/orion.ts
+++ b/src/lib/orion.ts
@@ -8,7 +8,7 @@ import { routeLogger } from './route-logger';
 import { OrionOptions } from './types';
 import { defaultOptions, validatePeerDeps } from './utils';
 
-export function orion(opts: OrionOptions = defaultOptions) {
+export function orion(opts?: OrionOptions) {
   opts = { ...defaultOptions, ...opts };
   const callSite = caller();
   const callerExt = path.extname(callSite).split('.')[1];
@@ -23,7 +23,7 @@ export function orion(opts: OrionOptions = defaultOptions) {
     cwd: path.dirname(callSite),
   });
 
-  const routes = gatherRoutes(paths);
+  const routes = gatherRoutes(paths, { base: opts.base });
 
   routeLogger(routes, { suffix, ext, ...opts.logging });
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface RouteFile {
 export interface OrionOptions {
   ext?: 'js' | 'mjs' | 'ts';
   suffix?: string;
+  base?: string;
   validation?: {
     enable?: boolean;
     options?: ValidationOptions | AsyncValidationOptions;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,7 @@ import { OrionOptions } from './types';
 
 export const defaultOptions = {
   suffix: 'route',
+  base: '',
   validation: {
     enable: true,
     options: { abortEarly: false, stripUnknown: true },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -103,3 +103,25 @@ describe('routes meta', () => {
     expect(body.from_mw).toEqual('from meta middleware');
   });
 });
+
+describe('root base', () => {
+  it('should correctly attach root base path', async () => {
+    app.use(orion({ ...defaultOptions, base: 'r1', suffix: 'r1' }));
+
+    const res = await request(app).get('/r1');
+    const body = res.body as Record<string, unknown>;
+
+    expect(body).toBeDefined();
+    expect(body.message).toEqual('root base test root');
+  });
+
+  it('should correctly attach root base path route', async () => {
+    app.use(orion({ ...defaultOptions, base: 'r1', suffix: 'r1' }));
+
+    const res = await request(app).get('/r1/path-1');
+    const body = res.body as Record<string, unknown>;
+
+    expect(body).toBeDefined();
+    expect(body.message).toEqual('root base test');
+  });
+});

--- a/test/test.r1.ts
+++ b/test/test.r1.ts
@@ -1,0 +1,14 @@
+import { Route } from '../src';
+
+export const routes: Route[] = [
+  {
+    path: '/',
+    method: 'GET',
+    handler: (_, res) => res.json({ message: 'root base test root' }),
+  },
+  {
+    path: 'path-1',
+    method: 'GET',
+    handler: (_, res) => res.json({ message: 'root base test' }),
+  },
+];


### PR DESCRIPTION
Orion can now accept an optional `base` parameter on the root config object.

With this, orion can append a base path to all routes found under a given suffix.

For ex:

```
const app = express();

const demoRouter = orion({ suffix: 'demo', base: 'api/demo' }); 
const fooRouter = orion({ suffix: 'foo.route', base: 'v1' });

app.use(demoRouter);
app.use(fooRouter);

app.listen( ... ) 
```

Sample corresponding mapped routes:

```http
GET /api/demo/some-route-in-route-file-with-demo-suffix
GET /v1/some-route-in-route-file-with-foo.route-suffix
```